### PR TITLE
Copy emoji to clipboard on click

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -7,8 +7,9 @@ document.addEventListener('DOMContentLoaded', e => {
             const span = document.createElement('span');
             span.classList.add('emoji');
             span.dataset.clipboardText = emoji;
-            span.textContent = emoji + ' ';
+            span.textContent = emoji;
             emojiParagraph.appendChild(span);
+            emojiParagraph.appendChild(document.createTextNode(' '));
         });
     });
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', e => {
+    // puts each emoji in a separate <span> element so they can be clicked
+    document.querySelectorAll('p:not(.lead)').forEach(emojiParagraph => {
+        const emojiChars = emojiParagraph.textContent.split(' ');
+        emojiParagraph.textContent = '';
+        emojiChars.forEach(emoji => {
+            const span = document.createElement('span');
+            span.classList.add('emoji');
+            span.dataset.clipboardText = emoji;
+            span.textContent = emoji + ' ';
+            emojiParagraph.appendChild(span);
+        });
+    });
+
+    // make the <span> elements copy to clipboard on click
+    new ClipboardJS('.emoji');
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -16,3 +16,7 @@ h5 {
 
 .grow { transition: all .2s ease-in-out; }
 .grow:hover { transform: scale(1.01); }
+
+.emoji {
+    cursor: pointer;
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
     <link rel="stylesheet" href="./assets/style.css">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
+    <script src="./assets/main.js"></script>
     <meta charset="UTF-8">
     <meta name="description" content="A massive emoji and symbol list, sorted into categories. 📖">
     <meta name="keywords" content="Emoji,Emoji List,Emojis,Emoji Dictionary, Emojipedia">


### PR DESCRIPTION
Resolves #1 

It splits each emoji into its own `<span>` tag, then uses [clipboard.js](https://clipboardjs.com) so it copies the emoji to your clipboard on click. The emoji change the cursor to `pointer` to not only indicate that it is clickable but also to make it clickable on iOS.

Perhaps the emoji could be made larger by increasing their font size for touch users, but that change wasn't made in this pull request.